### PR TITLE
[BUGFIX] Fix composer dependency for restler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.5.0",
         "typo3/cms-core": ">=6.2.14",
-        "luracast/restler": "3.0.0.20160315"
+        "luracast/restler": "~3.0.0@RC"
     },
     "require-dev": {
         "typo3/cms": "6.2.*",


### PR DESCRIPTION
This setting works for me, where the old one lead to a composer error:
```- aoe/restler dev-master requires luracast/restler 3.0.0.20160315 -> no matching package found.```