### PR TITLE
Initialize LinkVars to allow linking to translated pages

### DIFF
--- a/Classes/System/TYPO3/Loader.php
+++ b/Classes/System/TYPO3/Loader.php
@@ -156,6 +156,7 @@ class Loader implements SingletonInterface
         $tsfe->initTemplate();
         $tsfe->getConfigArray();
         $tsfe->newCObj();
+        $tsfe->calculateLinkVars();
         $this->isFrontEndRenderingInitialized = true;
     }
 


### PR DESCRIPTION
In the core, this initialization is done in typo3/sysext/frontend/Classes/Page/PageGenerator.php

Fixes: #18 