### PR TITLE
Prevent exception in CLI applications

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -29,5 +29,7 @@ if (false === isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigur
     ];
 }
 
-// Register request handler for API
-\TYPO3\CMS\Core\Core\Bootstrap::getInstance()->registerRequestHandlerImplementation(\Aoe\Restler\Http\RestRequestHandler::class);
+if (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_FE) {
+    // Register request handler for API
+    \TYPO3\CMS\Core\Core\Bootstrap::getInstance()->registerRequestHandlerImplementation(\Aoe\Restler\Http\RestRequestHandler::class);
+}


### PR DESCRIPTION
Registering a HTTP RequestHandler in ext_localconf.php
using Bootstrap::registerAdditionalRequestHandlers can
only be performed for web requests, not for CLI requests.
The TYPO3 CLI Application expects another interface
than the HTTP Applications do.

Adding a RequestHandler unconditionally results in following
exception when using the console interface
(example for TYPO3 8.7.10):

vendor/bin/typo3

  Uncaught TYPO3 Exception Argument 1 passed to
  Aoe\Restler\Http\RestRequestHandler::canHandleRequest()
  must be an instance of Psr\Http\Message\ServerRequestInterface, instance of
  Symfony\Component\Console\Input\ArgvInput given, called in
  […]/vendor/typo3/cms/typo3/sysext/core/Classes/Core/Bootstrap.php on line 285
  thrown in file […]/restler/Classes/Http/RestRequestHandler.php
  in line 86