### PR TITLE
[TASK] Removed internal dist url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,9 +75,5 @@
             "cms-package-dir": "{$vendor-dir}/typo3/cms",
             "web-dir": ".Build/Web"
         }
-    },
-    "dist": {
-        "url": "https://extranet.aoe.com/artifactory/congstar-composer-internal-local/aoe/restler/restler-build.552.zip",
-        "type": "zip"
     }
 }


### PR DESCRIPTION
I'm pretty sure this url was not meant to be published. Currently, it is not possible to install the package, since the dist url requires authentication