### PR TITLE
fixed no matches when working with PageTypeSuffix

### DIFF
--- a/Classes/System/TYPO3/RestlerEnhancer.php
+++ b/Classes/System/TYPO3/RestlerEnhancer.php
@@ -37,7 +37,7 @@ class RestlerEnhancer implements DecoratingEnhancerInterface
      */
     public function getRoutePathRedecorationPattern(): string
     {
-        return '';
+        return '.$';
     }
 
     /**


### PR DESCRIPTION
When using PageTypeSuffix and e.g. the default setting for '.html', the empty return value leads to an error when requesting 'normal' pages.