### PR TITLE
[TASK] Change regexp to not match any single character at end of path.

### DIFF
--- a/Classes/System/TYPO3/RestlerEnhancer.php
+++ b/Classes/System/TYPO3/RestlerEnhancer.php
@@ -37,7 +37,7 @@ class RestlerEnhancer implements DecoratingEnhancerInterface
      */
     public function getRoutePathRedecorationPattern(): string
     {
-        return '.$';
+        return '\.[^.]+$';
     }
 
     /**


### PR DESCRIPTION
The current regexp matches any single character at end of path.
For us the path '/datenschutz' leads to a 404 error.
This update changes the regexp to match any file ending (a dot followed by some non-dot chars).