### PR TITLE
[MOD] Use echo && die for Typo3 V8 output.

### DIFF
--- a/Classes/System/Restler/RestlerExtended.php
+++ b/Classes/System/Restler/RestlerExtended.php
@@ -63,8 +63,10 @@ class RestlerExtended extends Restler
     {
         parent::__construct($productionMode, $refreshCache);
 
-        // restler uses echo;die otherwise and then Typo3 standard mechanisms will not be called
-        Defaults::$returnResponse = true;
+        if (interface_exists('\Psr\Http\Server\MiddlewareInterface')) {
+            // restler uses echo;die otherwise and then Typo3 standard mechanisms will not be called
+            Defaults::$returnResponse = true;
+        }
 
         // adds format support for application/hal+json
         Scope::$classAliases['HalJsonFormat'] = 'Aoe\Restler\System\Restler\Format\HalJsonFormat';


### PR DESCRIPTION
Some people report problems running under Typo3 V8. There seems to be a problem due to the settings for restler to return the output instead of just echo && die.
