### PR TITLE
[TASK] Avoid warnings of undefined index string -1 offset in Dispatcher

### DIFF
--- a/Classes/System/Dispatcher.php
+++ b/Classes/System/Dispatcher.php
@@ -69,19 +69,24 @@ class Dispatcher extends RestlerBuilderAware implements MiddlewareInterface
     {
         // set base path depending on site config
         $site = $request->getAttribute('site');
-        if ($site !== null && $site instanceof \TYPO3\CMS\Core\Site\Entity\Site) {
+        if ($site instanceof \TYPO3\CMS\Core\Site\Entity\Site) {
             $siteBasePath = $request->getAttribute('site')
                 ->getBase()
                 ->getPath();
-            if ($siteBasePath !== '/' && $siteBasePath[-1] !== '/') {
+            if ($siteBasePath === '/' || $siteBasePath === '') {
+                $siteBasePath = null;
+            } else if ($siteBasePath[-1] !== '/') {
                 $siteBasePath .= '/';
             }
         } else {
-            $siteBasePath = '/';
+            $siteBasePath = null;
         }
 
-        // set url with base path removed
-        return '/' . rtrim(preg_replace('%^' . preg_quote($siteBasePath, '%') . '%', '', $request->getUri()->getPath()), '/');
+        if ($siteBasePath) {
+            return '/' . rtrim(preg_replace('%^' . preg_quote($siteBasePath, '%') . '%', '', $request->getUri()->getPath()), '/');
+        }
+
+        return $request->getUri()->getPath();
     }
 
     private function isRestlerUrl($uri): bool


### PR DESCRIPTION
Depending on how the site base path is configured (if it is set or not) Dispatcher
class will try to set or append `/` to it. If the site base path will be set to an empty
string we will end up with PHP warning:

`Core: Error handler (FE): PHP Warning: Uninitialized string offset -1 in /code/vendor/aoe/restler/Classes/System/Dispatcher.php line 76` 

becasue script tries to check undefined string index.

This commit changes how the site base path is handled here. We will remove if from
URI path only if site base path:

- was not an empty string
- was not set to `/`

If it was set to an empty string or just slash, we will return URI path directly.