### PR TITLE
[TASK] do not use objectManager for dependency-injection (use objectManager only as fallback when error occurs)

### DIFF
--- a/.code-quality/phpstan-baseline.neon
+++ b/.code-quality/phpstan-baseline.neon
@@ -56,8 +56,3 @@ parameters:
 				message: "#^Strict comparison using \\=\\=\\= between bool and null will always evaluate to false\\.$#"
 				count: 1
 				path: ../Classes/System/Restler/Format/HalJsonFormat.php
-
-			-
-				message: "#^Strict comparison using \\=\\=\\= between Aoe\\\\Restler\\\\System\\\\Restler\\\\Builder and null will always evaluate to false\\.$#"
-				count: 1
-				path: ../Classes/System/RestlerBuilderAware.php

--- a/Classes/System/TYPO3/Loader.php
+++ b/Classes/System/TYPO3/Loader.php
@@ -191,10 +191,10 @@ class Loader implements SingletonInterface
         $this->typoScriptFrontendInitialization->process($this->getRequest(), $this->mockRequestHandler);
         self::setRequest($this->mockRequestHandler->getRequest());
 
-        if ($forcedTemplateParsing === true) {
+        if ($forcedTemplateParsing) {
             // Force TemplateParsing (will slow down the called REST-endpoint a little bit):
             // Otherwise we can't render TYPO3-content in REST-endpoints, when TYPO3-cache 'pages' already exists
-            /* @var $controller TypoScriptFrontendController */
+            /** @var TypoScriptFrontendController $controller */
             $controller = $this->getRequest()->getAttribute('frontend.controller');
             $controller->getContext()->setAspect('typoscript', new TypoScriptAspect($forcedTemplateParsing));
         }

--- a/Tests/Unit/System/Restler/BuilderTest.php
+++ b/Tests/Unit/System/Restler/BuilderTest.php
@@ -40,7 +40,6 @@ use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use InvalidArgumentException;
 
 /**
@@ -223,15 +222,7 @@ class BuilderTest extends BaseTest
         Scope::$resolver = null;
 
         $requestedClass = ExtensionConfiguration::class;
-
-        $objectManagerMock = $this->getMockBuilder(ObjectManager::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['get'])
-            ->getMock();
-        $objectManagerMock
-            ->expects(self::once())->method('get')->with($requestedClass)
-            ->willReturn($this->extensionConfigurationMock);
-        GeneralUtility::setSingletonInstance(ObjectManager::class, $objectManagerMock);
+        GeneralUtility::setSingletonInstance($requestedClass, $this->extensionConfigurationMock);
 
         $this->callUnaccessibleMethodOfObject($this->builder, 'setAutoLoading');
 


### PR DESCRIPTION
Hi,
der TYPO3-objectManager ist in TYPO3v11 deprecated und wird mit TYPO3v12 entfernt. Ich hab den Code nun so umgebaut, dass folgendes passiert:
Wenn die Extension z.B. einen REST-Controller erzeugen muss, verwendet sie nun nicht mehr den TYPO3-objectManager (um den REST-Controller zu erzeugen - weil das würde einen 'deprecated-log-eintrag' erzeugen), sondern die Extension verwendet nun die "Standard-TYPO3-Dependency-Injection". Wenn das aber fehlschlägt (das kann passieren, wenn ein REST-Controller diese neue "Standard-TYPO3-Dependency-Injection" noch nicht unterstützt, so wird als Fallback dann doch der TYPO3-objectManager (wie bisher) verwendet und es wird ein 'deprecated-log-eintrag' erzeugt, der darauf hinweißt, dass z.B. der REST-Controller angepasst werden muss (damit er eben diese neue "Standard-TYPO3-Dependency-Injection" unterstützt.

Ich hab natürlich getestet, dass die Änderungen funktionieren (und auch dass ein 'deprecated-log-eintrag' erzeugt wird, wenn REST-controller die "Standard-TYPO3-Dependency-Injection" nicht unterstützen (die eft_pim-Controller gehören z.B. dazu).