### PR TITLE
[BUGFIX] undefined array key fix for PHP8.0

### DIFF
--- a/Classes/System/TYPO3/Cache.php
+++ b/Classes/System/TYPO3/Cache.php
@@ -97,7 +97,7 @@ class Cache implements SingletonInterface
         array $responseHeaders
     ) {
         $identifier = $this->buildIdentifier($requestUri, $requestGetData);
-        $frontendCacheExpires = (int) $apiMethodInfoMetadata['expires'];
+        $frontendCacheExpires = (int) ($apiMethodInfoMetadata['expires'] ?? 0);
         $typo3CacheExpires = (int) $apiMethodInfoMetadata[self::API_METHOD_TYPO3CACHE_EXPIRES];
         $typo3CacheTags = explode(',', $apiMethodInfoMetadata[self::API_METHOD_TYPO3CACHE_TAGS]);
 


### PR DESCRIPTION
Missing `@expires` annotation causes a warning when using PHP 8. 
Below patch will pass `0` to the cache set method, meaning unlimited lifetime. But maybe `null` is desirable (default lifetime)?